### PR TITLE
well pdf generation will throw TypeError: page.pdf is not a function

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -1,5 +1,6 @@
 // scraping with Puppeteer example
 const puppeteer = require('puppeteer');
+const puppeteerFirefox = require('puppeteer-firefox');
 const expect = require('expect');
 
 (async () => {
@@ -9,13 +10,13 @@ const expect = require('expect');
 
   await page.setViewport({ width: 1024, height: 768 })
 
-  await page.goto('https://www.liligo.fr/', { waitUntil: 'networkidle2' })
+  await page.goto('https://www.liligo.fr/')
   let linkText = await page.evaluate(el => el.innerHTML, await page.$('body > header > h1 > span > a'))
     console.log(linkText)
     expect(linkText).toBe('vol pas cher')
       console.log("it's a match")
   let bodyHTML = await page.evaluate(() => document.body.innerHTML)
-  //  console.log(bodyHTML)
+  console.log(bodyHTML)
 
   await page.pdf({ path: './tmp/lilihome.pdf' })
     console.log('pdf is created')


### PR DESCRIPTION
Chrome for scraping is still more stable. page.pdf() is not implmntd yet. Let's see the next releases: https://aslushnikov.github.io/ispuppeteerfirefoxready/